### PR TITLE
docs(linux): add grep command reference

### DIFF
--- a/docs/devops/linux/shell/grep.md
+++ b/docs/devops/linux/shell/grep.md
@@ -1,0 +1,48 @@
+# grep
+
+`grep` is used to search for a specific string or pattern inside files or command outputs. It is an essential tool for troubleshooting, filtering data, and analyzing log files.
+
+---
+
+### Basic Usage
+
+Search for a specific word in a single file:
+
+```bash title="Basic search"
+grep "error" /var/log/syslog
+```
+
+### Useful Flags
+
+grep provides a number of options that control every aspect of its behavior. The most widely used options are:
+
+-i - Case-insensitive search: Ignores upper and lower case distinctions.
+
+-r - Search recursively: Searches through all files within a directory and its subdirectories.
+
+-v - Invert match: Displays all lines that do not contain the pattern.
+
+-n - Show line numbers: Displays the line number before each matched line.
+
+Examples by Flag:
+
+=== "-i (Case-insensitive)"
+
+```bash title="Ignore case"
+grep -i "error" app.log
+```
+=== "-r (Recursive)"
+
+```bash title="Search in directory"
+grep -r "DB_PASSWORD" /etc/
+```
+=== "-v (Invert)"
+
+```bash title="Filter out logs"
+grep -v "INFO" server.log
+```
+=== "-n (Line numbers)"
+
+```bash title="Show lines"
+grep -n "Exception" error.log
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
             - "nmap": devops/linux/shell/nmap.md
             - "netstat, ss, ps": devops/linux/shell/netstat.md
             - "scp": devops/linux/shell/scp.md
+            - "grep": devops/linux/shell/grep.md
         - "Tooling": devops/linux/tooling.md
         - "Tips": devops/linux/tips.md
     - "AWS":
@@ -309,8 +310,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   - search


### PR DESCRIPTION
Hi team,

I added a quick reference guide for the `grep` command under the Shell Commands section. 

Tested locally and everything looks good. Hope this helps!